### PR TITLE
fix: parse mongo connection string uriOptions

### DIFF
--- a/packages/strapi-connector-mongoose/lib/index.js
+++ b/packages/strapi-connector-mongoose/lib/index.js
@@ -7,7 +7,6 @@
 // Public node modules.
 const path = require('path');
 const fs = require('fs');
-const { URL } = require('url');
 const _ = require('lodash');
 const mongoose = require('mongoose');
 require('mongoose-long')(mongoose);
@@ -64,7 +63,7 @@ module.exports = function (strapi) {
 
       const { uri, host, port, username, password, database, srv } = connection.settings;
 
-      const uriOptions = uri ? Object.fromEntries(new URL(uri).searchParams) : {};
+      const uriOptions = uri ? new URLSearchParams(uri.split('?').pop()) : {};
       const { authenticationDatabase, ssl, debug } = _.defaults(
         connection.options,
         uriOptions,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/akemona/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Parse mongodb connection string `<options>` using `URLSearchParams()` instead of parsing the whole URL as `URL`

### Why is it needed?

A mongodb connection string with [multiple hosts](https://www.mongodb.com/docs/manual/reference/connection-string/) is not a valid URL in [NodeJS](https://nodejs.org/docs/latest/api/url.html#urlprotocol). As such a connection string in the format `mongodb://foo:123,bar:432/?a=b` cannot be parsed as `URL`.

### How to test it?

Set `uri` in database settings to `mongodb://foo:123,bar:432/?a=b` and start strapi. Strapi will fail to start, but with error `ENOTFOUND` and not with error ` Invalid URL`.

### Related issue(s)/PR(s)
#14
